### PR TITLE
Switch to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
   - 2.12.3
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   ## This runs the template with the default parameters, and runs test within the templated app.


### PR DESCRIPTION
Some builds are failing: https://travis-ci.org/CodelyTV/scala-intro-examples/jobs/560113860
Trying to use the pre-installed JDK in Travis: https://docs.travis-ci.com/user/reference/xenial/